### PR TITLE
Specify the timezone in GitHub Action

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -3,14 +3,22 @@ name: Update
 on:
   workflow_dispatch:
   schedule:
-    - cron: '15 16 * * *'
+    - cron: '15 17 * * *'
+      timezone: 'Europe/Paris'
     - cron: '35 18-23 * * 3'
+      timezone: 'Europe/Paris'
     - cron: '35 0-12 * * 4'
-    - cron: '*/5 13-15 * * 4'
+      timezone: 'Europe/Paris'
+    - cron: '*/5 13-16 * * 4'
+      timezone: 'Europe/Paris'
     - cron: '35 0-12,18-23 11-31 12 *'
-    - cron: '*/5 13-15 11-31 12 *'
+      timezone: 'Europe/Paris'
+    - cron: '*/5 13-16 11-31 12 *'
+      timezone: 'Europe/Paris'
     - cron: '35 0-12,18-23 1-6 1 *'
-    - cron: '*/5 13-15 1-6 1 *'
+      timezone: 'Europe/Paris'
+    - cron: '*/5 13-16 1-6 1 *'
+      timezone: 'Europe/Paris'
 
 jobs:
   scheduled:


### PR DESCRIPTION
This allows to automatically take into account daylight saving time.

https://github.blog/changelog/2026-03-19-github-actions-late-march-2026-updates/#github-actions-timezone-support-for-scheduled-workflows